### PR TITLE
Add nonewlines pass

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <GoCodeStyleSettings>
       <option name="ADD_PARENTHESES_FOR_SINGLE_IMPORT" value="true" />
       <option name="ADD_LEADING_SPACE_TO_COMMENTS" value="true" />

--- a/analysis/passes/nonewlines/nonewlines.go
+++ b/analysis/passes/nonewlines/nonewlines.go
@@ -1,0 +1,83 @@
+package nonewlines
+
+import (
+	"go/ast"
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const Doc = `check that there are no unnecessary newlines in the code`
+
+// nolint: gochecknoglobals,golint
+var Analyzer = &analysis.Analyzer{
+	Name:     "nonewlines",
+	Doc:      Doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.BlockStmt)(nil),
+		(*ast.CompositeLit)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		pos := n.Pos()
+		var lbrace, rbrace token.Pos
+		var size int
+		var incomplete bool
+		var nodeType string
+
+		switch n := n.(type) {
+		case *ast.BlockStmt:
+			lbrace = n.Lbrace
+			rbrace = n.Rbrace
+			size = len(n.List)
+			nodeType = "block statements"
+
+		case *ast.CompositeLit:
+			lbrace = n.Lbrace
+			rbrace = n.Rbrace
+			size = len(n.Elts)
+			incomplete = n.Incomplete
+			nodeType = "composite literals"
+		}
+
+		startPosition := pass.Fset.Position(lbrace)
+		endPosition := pass.Fset.Position(rbrace)
+
+		// Empty new line is allowed in an empty block statement
+		// One line blocks are also valid
+		if size == 0 || incomplete || startPosition.Line == endPosition.Line {
+			return
+		}
+
+		nextLine := lbrace
+		for pass.Fset.Position(nextLine).Line == startPosition.Line {
+			nextLine++
+		}
+
+		previousLine := rbrace - 1
+		for pass.Fset.Position(previousLine).Line == endPosition.Line {
+			previousLine--
+		}
+
+		firstPos := pass.Fset.Position(nextLine)
+		secondPos := pass.Fset.Position(nextLine + 1)
+
+		lastButOnePos := pass.Fset.Position(previousLine - 1)
+		lastPos := pass.Fset.Position(previousLine)
+
+		if firstPos.Line != secondPos.Line || lastPos.Line != lastButOnePos.Line {
+			pass.Reportf(pos, "%s should not start or end with empty lines", nodeType)
+		}
+	})
+
+	return nil, nil
+}

--- a/analysis/passes/nonewlines/nonewlines_test.go
+++ b/analysis/passes/nonewlines/nonewlines_test.go
@@ -1,0 +1,11 @@
+package nonewlines
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestNoNewlines(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), Analyzer)
+}

--- a/analysis/passes/nonewlines/testdata/block.go
+++ b/analysis/passes/nonewlines/testdata/block.go
@@ -1,0 +1,82 @@
+package testdata
+
+import (
+	"fmt"
+)
+
+func BlockFirstEmptyLine() { // want "block statements should not start or end with empty lines"
+
+	// do something here
+	fmt.Println("something")
+	fmt.Println("something")
+}
+
+func BlockMultiLineFirstEmptyLine(
+	a string,
+) { // want "block statements should not start or end with empty lines"
+
+	// do something here
+	fmt.Println("something")
+	fmt.Println("something")
+}
+
+func BlockLastEmptyLine() { // want "block statements should not start or end with empty lines"
+	// do something here
+	fmt.Println("something")
+	fmt.Println("something")
+
+}
+
+func BlockBothFirstAndLastEmptyLine() { // want "block statements should not start or end with empty lines"
+
+	// do something here
+	fmt.Println("something")
+	fmt.Println("something")
+
+}
+
+func BlockBothMultiLineFirstAndLastEmptyLine(
+	a string,
+) { // want "block statements should not start or end with empty lines"
+
+	// do something here
+	fmt.Println("something")
+	fmt.Println("something")
+
+}
+
+func BlockEmpty() {
+
+}
+
+func BlockOneLine() { fmt.Println("something") }
+
+func BlockInline() {
+	{ // want "block statements should not start or end with empty lines"
+
+		// do something here
+		fmt.Println("something")
+		fmt.Println("something")
+	}
+
+	{ // want "block statements should not start or end with empty lines"
+		// do something here
+		fmt.Println("something")
+		fmt.Println("something")
+
+	}
+
+	{ // want "block statements should not start or end with empty lines"
+
+		// do something here
+		fmt.Println("something")
+		fmt.Println("something")
+
+	}
+
+	{
+		// do something here
+		fmt.Println("something")
+		fmt.Println("something")
+	}
+}

--- a/analysis/passes/nonewlines/testdata/composite_literal.go
+++ b/analysis/passes/nonewlines/testdata/composite_literal.go
@@ -12,37 +12,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package testdata
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"golang.org/x/tools/go/analysis/multichecker"
-
-	"github.com/banzaicloud/banzailint/analysis/passes/nonewlines"
-)
-
-// Provisioned by ldflags
-// nolint: gochecknoglobals
-var (
-	version    string
-	commitHash string
-	buildDate  string
-)
-
-func main() {
-	args := os.Args
-	progname := filepath.Base(args[0])
-
-	if len(args) > 1 && args[1] == "version" {
-		fmt.Printf("%s version %s (%s) built on %s\n", progname, version, commitHash, buildDate)
-
-		os.Exit(0)
+func CompositeLiteral() {
+	type a struct {
+		a string
 	}
 
-	multichecker.Main(
-		nonewlines.Analyzer,
-	)
+	type b struct {
+		b string
+	}
+
+	_ = a{ // want "composite literals should not start or end with empty lines"
+
+		a: "a",
+	}
+
+	// @formatter:off
+	_ = a{ // want "composite literals should not start or end with empty lines"
+		a: "a",
+
+	}
+
+	_ = a{ // want "composite literals should not start or end with empty lines"
+
+		a: "a",
+
+	}
+	// @formatter:on
+
+	_ = a{
+		a: "a",
+	}
+
+	_ = a{
+	}
+
+	_ = a{
+
+	}
+
+	_ = a{a: "a"}
+
+	_ = map[string]string{
+		"key": "value",
+	}
+
+	_ = map[string]string{"key": "value"}
 }


### PR DESCRIPTION
This PR adds a pass that checks if the code contains unnecessary newlines.

The first implementation checks if block statements and composite literals start or end with a trailing newline.